### PR TITLE
Update license of function_name-proc-macro to use SPDX identifier

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "function_name"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>"]
 edition = "2018"
 
@@ -14,7 +14,7 @@ readme = "README.md"
 license = "MIT"
 
 [dependencies]
-function_name-proc-macro = { version = "0.2.0", path = "proc-macro" }
+function_name-proc-macro = { version = "0.2.1", path = "proc-macro" }
 
 [features]
 default = []

--- a/proc-macro/Cargo.toml
+++ b/proc-macro/Cargo.toml
@@ -3,7 +3,7 @@ proc-macro = true
 
 [package]
 name = "function_name-proc-macro"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>"]
 edition = "2018"
 
@@ -13,7 +13,7 @@ homepage = "https://crates.io/crates/function_name"
 repository = "https://github.com/danielhenrymantilla/rust-function_name"
 keywords = ["macro", "proc-macro", "proc-macro-attribute", "name", "function_name"]
 
-license-file = "../LICENSE"
+license = "MIT"
 
 [dependencies]
 proc-macro-crate = "0.1.4"


### PR DESCRIPTION
I have updated the `proc-macro` subproject `Cargo.toml` to use the `license` keyword instead of `license-file` as it uses just the standard MIT license.

Cargo manual [states](https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields):

`If a package is using a nonstandard license, then the license-file field may be specified in lieu of the license field.`

On top of this by specifying the SPDX field, your crate will be correctly categorize, so that it can be displayed appropriately on crates.io / lib.rs, be handled by crawlers, used for ecosystem analysis, etc..